### PR TITLE
No copy message sending

### DIFF
--- a/Facepunch.Steamworks.Test/NetworkingSockets.cs
+++ b/Facepunch.Steamworks.Test/NetworkingSockets.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +16,7 @@ namespace Steamworks
     [DeploymentItem( "steam_api.dll" )]
     public partial class NetworkingSocketsTest
 	{
+
 		void DebugOutput( NetDebugOutput type, string text )
 		{
 			Console.WriteLine( $"[NET:{type}]\t\t{text}" );
@@ -158,6 +161,33 @@ namespace Steamworks
 				var n = NetAddress.AnyIp( 5543 );
 				Assert.AreEqual( n.ToString(), "[::]:5543" );
 			}
+		}
+
+		[TestMethod]
+		public void SendMessageSpeedTest() {
+			// Create manager with dummy ip
+        	var manager = SteamNetworkingSockets.ConnectRelay<ConnectionManager>(0, 0);
+
+			// Create data
+			Span<float> data = new float[1000000];
+			Span<byte> byte_data = MemoryMarshal.AsBytes(data);
+
+			Stopwatch sw = new Stopwatch();
+			sw.Start();
+
+			for (int i = 0; i < 10000; i++)
+			{
+				unsafe {
+					fixed (byte* ptr = byte_data) {
+						manager.Connection.SendMessage((IntPtr)ptr, byte_data.Length);
+					}
+				}
+			}
+
+			sw.Stop();
+
+			Console.WriteLine($"Time Elapsed: {sw.Elapsed}");
+			Assert.Inconclusive();
 		}
 	}
 

--- a/Facepunch.Steamworks.Test/NetworkingSockets.cs
+++ b/Facepunch.Steamworks.Test/NetworkingSockets.cs
@@ -176,12 +176,12 @@ namespace Steamworks
 	        server.onMessage += OnMessage;
 
 			// Create data
-			var raw_data = new float[1000000];
+			var raw_data = new float[100];
 
 			Stopwatch sw = new Stopwatch();
 			sw.Start();
 
-			for (int i = 0; i < 10000; i++)
+			for (int i = 0; i < 100; i++)
 			{
 				var dataHandle = GCHandle.Alloc(raw_data, GCHandleType.Pinned);
 

--- a/Facepunch.Steamworks/Networking/ConnectionManager.cs
+++ b/Facepunch.Steamworks/Networking/ConnectionManager.cs
@@ -62,7 +62,7 @@ namespace Steamworks
 					{
 						Connecting = true;
 
-						onConnecting( info );
+						onConnecting?.Invoke( info );
 					}
 					break;
 				case ConnectionState.Connected:
@@ -71,7 +71,7 @@ namespace Steamworks
 						Connecting = false;
 						Connected = true;
 
-						onConnected( info );
+						onConnected?.Invoke( info );
 					}
 					break;
 				case ConnectionState.ClosedByPeer:
@@ -82,7 +82,7 @@ namespace Steamworks
 						Connecting = false;
 						Connected = false;
 
-						onDisconnected( info );
+						onDisconnected?.Invoke( info );
 					}
 					break;
 			}
@@ -233,7 +233,7 @@ namespace Steamworks
 		{
 			try
 			{
-				onMessage(new Span<byte>(msg->DataPtr.ToPointer(), msg->DataSize), msg->MessageNumber, msg->RecvTime, msg->Channel);
+				onMessage?.Invoke(new Span<byte>(msg->DataPtr.ToPointer(), msg->DataSize), msg->MessageNumber, msg->RecvTime, msg->Channel);
 			}
 			finally
 			{

--- a/Facepunch.Steamworks/Networking/NetMsg.cs
+++ b/Facepunch.Steamworks/Networking/NetMsg.cs
@@ -17,8 +17,21 @@ namespace Steamworks.Data
 		internal IntPtr ReleasePtr;
 		internal int Channel;
 		internal SendType Flags;
-		internal long UserData;
+		internal GCHandle64 DataHandle;
 		internal ushort IdxLane;
 		internal ushort _pad1__;
+
+		
+	}
+
+	[StructLayout( LayoutKind.Sequential, Size = 4 )]
+	internal struct GCHandle64 {
+		public GCHandle value;
+
+		public GCHandle64( GCHandle handle ) : this() => value = handle;
+
+		public static implicit operator GCHandle(GCHandle64 handle) => handle.value;
+		public static implicit operator GCHandle64(GCHandle handle) => new(handle);
 	}
 }
+


### PR DESCRIPTION
Implemented a new overload for message sending in the Connection class that sends messages without allocating and copying the message data to unmanaged memory. This change also removes the need for a custom garbage collector to track the allocated unmanaged memory and ensure deallocation.

As this takes the function from linear to constant time, it has resulted in massive, and probably insignificant, speedup. Note that overhead has also been reduced, so a speedup is achieved even in the simplest case.

This change is mostly interesting because we're passing managed memory into an unmanaged library while providing it with a callback to notify the garbage collector of its use. 